### PR TITLE
Ds mirror

### DIFF
--- a/apps/catalog/management/commands/mirror.py
+++ b/apps/catalog/management/commands/mirror.py
@@ -1,0 +1,14 @@
+import importlib
+import structlog
+from django_typer.management import Typer
+from ingestion.utils import logger
+
+app = Typer()
+
+
+@app.command()
+def command(self):
+    pass
+
+def load_mirror_datasets():
+    pass

--- a/apps/catalog/management/commands/mirror.py
+++ b/apps/catalog/management/commands/mirror.py
@@ -2,6 +2,7 @@ import importlib
 import structlog
 from django_typer.management import Typer
 from ingestion.utils import logger
+from apps.catalog.models import DataSet, Publisher, DataSetFile
 
 app = Typer()
 
@@ -10,5 +11,31 @@ app = Typer()
 def command(self):
     pass
 
-def load_mirror_datasets():
-    pass
+
+def mirror_datasets():
+    mirror_publishers = Publisher.objects.filter(mirror=True)
+    mirror_publishers_names = set(mirror_publishers.values_list("name", flat=True))
+
+
+    # need to figure out most efficient way to go about this, can either:
+    #
+    # 1) query DataSetFile obj directly (based on dataset__publisher) --> more efficient? 
+    #    but then need to access DataSet somehow later for last_mirrored update, 
+    #    also will this make updating DataSetFile urls complicated? (no unique id on DataSetFile model)
+    #
+    # 2) iterate over DataSet obj, then access DataSetFile for each --> have access to DataSet and DataSetFile for changes
+    
+    for publisher_name in mirror_publishers_names:
+        
+        dataset_files = DataSetFile.objects.filter(dataset__publisher=publisher_name)
+        dataset_files_urls = set(dataset_files.values_list("url", flat=True))
+        print(dataset_files_urls) # would actually download files, save to block storage, redirect dataset url, etc. here
+
+
+def update_last_mirrored(publisher: str, upstream_id: str):
+    dataset = DataSet.objects.filter(publisher__name=publisher, upstream_id=upstream_id)
+    #dataset.update(last_mirrored=Time.now())
+            
+            
+
+

--- a/apps/catalog/management/commands/mirror.py
+++ b/apps/catalog/management/commands/mirror.py
@@ -2,6 +2,7 @@ import importlib
 import structlog
 from django_typer.management import Typer
 from ingestion.utils import logger
+from django.utils import timezone
 from apps.catalog.models import DataSet, Publisher, DataSetFile
 
 app = Typer()
@@ -9,33 +10,48 @@ app = Typer()
 
 @app.command()
 def command(self):
-    pass
+    self.secho("Running dataset mirroring for applicable publishers.", fg="blue")
+    mirror_datasets()
 
 
 def mirror_datasets():
+    # retrieve all publishers marked for mirroring, flatten names into list
     mirror_publishers = Publisher.objects.filter(mirror=True)
     mirror_publishers_names = set(mirror_publishers.values_list("name", flat=True))
 
-
-    # need to figure out most efficient way to go about this, can either:
-    #
-    # 1) query DataSetFile obj directly (based on dataset__publisher) --> more efficient? 
-    #    but then need to access DataSet somehow later for last_mirrored update, 
-    #    also will this make updating DataSetFile urls complicated? (no unique id on DataSetFile model)
-    #
-    # 2) iterate over DataSet obj, then access DataSetFile for each --> have access to DataSet and DataSetFile for changes
-    
     for publisher_name in mirror_publishers_names:
-        
-        dataset_files = DataSetFile.objects.filter(dataset__publisher=publisher_name)
-        dataset_files_urls = set(dataset_files.values_list("url", flat=True))
-        print(dataset_files_urls) # would actually download files, save to block storage, redirect dataset url, etc. here
+        # retrieve all datasets for given publisher, flatten upstream ids into list
+        datasets = DataSet.objects.filter(publisher__name=publisher_name)
+        dataset_ids = set(datasets.values_list("upstream_id", flat=True))
+
+        for dataset_id in dataset_ids:
+            # retrieve all dataset file objects for given dataset
+            dataset_files = DataSetFile.objects.filter(
+                dataset__upstream_id=dataset_id, dataset__publisher__name=publisher_name
+            )
+            updated_dataset_files = []
+
+            for dataset_file in dataset_files:
+                # use helper method for new block storage url
+                new_url = download_dataset(dataset_file.url)
+
+                # update url, add dataset file to list for bulk update later
+                dataset_file.url = new_url
+                updated_dataset_files.append(dataset_file)
+
+            # chatgpt helped with this -->
+            # asked if possible to update multiple objects at once with diff values
+            DataSetFile.objects.bulk_update(updated_dataset_files, ["url"])
+
+        # chatgpt --> asked if way to update multiple objects at once with same value
+        DataSet.objects.filter(publisher__name=publisher_name, upstream_id__in=dataset_ids).update(
+            last_mirrored=timezone.now()
+        )
+
+        logger.info(f"Datasets successfully mirrored for publisher: {publisher_name}")
 
 
-def update_last_mirrored(publisher: str, upstream_id: str):
-    dataset = DataSet.objects.filter(publisher__name=publisher, upstream_id=upstream_id)
-    #dataset.update(last_mirrored=Time.now())
-            
-            
-
-
+# will update this once block storage info sorted out
+def download_dataset(url: str):
+    block_url = ""
+    return block_url

--- a/apps/catalog/models.py
+++ b/apps/catalog/models.py
@@ -45,6 +45,7 @@ class Publisher(models.Model):
     name = models.TextField()
     kind = models.CharField(max_length=2, choices=PublisherKind)
     url = models.URLField()
+    mirror = models.BooleanField()
 
     def __str__(self):
         return f"{self.name} - {self.kind}"
@@ -125,6 +126,7 @@ class DataSet(models.Model):
         CuratedCollection, null=True, blank=True, related_name="datasets"
     )
     quality_score = models.IntegerField()
+    last_mirrored = models.DateTimeField(null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 


### PR DESCRIPTION
Implementation for mirror.py command --> will eventually be used to mirror dataset files for all applicable Publishers to block storage location (TBD), and update DataSetFile information/location accordingly.

Publishers will be manually marked for mirroring in admin through "mirror" boolean field.